### PR TITLE
Fix: throw error in callback

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -58,7 +58,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     var json;
 
     if (err) {
-      throw new InternalOAuthError("Failed to fetch user profile", err);
+      return done(new InternalOAuthError("Failed to fetch user profile", err));
     }
 
     try {


### PR DESCRIPTION
Without this fix, the zoom causes uncaught exception and could crash the app that uses it.