### PR TITLE
Update strategy - Zoom requires Authorization Header

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -54,6 +54,8 @@ util.inherits(Strategy, OAuth2Strategy);
  * @access protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
+  // as of February 24th, 2023, Zoom requires Authorization Header in all the API requests
+  this._oauth2.useAuthorizationHeaderforGET(true);
   this._oauth2.get(this._profileUrl, accessToken, function(err, body, res) {
     var json;
 


### PR DESCRIPTION
as of February 24th, 2023, Zoom requires Authorization Header in all the API requests